### PR TITLE
Fixed formatting errors to allow proper Sphinx compilation

### DIFF
--- a/carta/scriptedClient/cartavis.py
+++ b/carta/scriptedClient/cartavis.py
@@ -250,11 +250,12 @@ class Cartavis:
         pluginList: list
             A list of strings representing plugin names.
             Valid plugin names [NOTE: this list may not be complete]:
-                CasaImageLoader
-                Animator
-                Colormap
-                Histogram
-                Hidden
+
+                - CasaImageLoader
+                - Animator
+                - Colormap
+                - Histogram
+                - Hidden
 
         Returns
         -------
@@ -399,7 +400,7 @@ class Cartavis:
         Create a new Snapshot object that can be saved.
 
         Parameters
-        ---------
+        ----------
         sessionId: string
             An identifier for a user session.
 

--- a/carta/scriptedClient/image.py
+++ b/carta/scriptedClient/image.py
@@ -135,10 +135,12 @@ class Image(CartaView):
     def centerWithRadius(self, x, y, radius, dim='width'):
         """
         A convenience function:
+
             something that takes a centre and a radius and computes a
             ZoomLevel to put the centre at the centre of the viewer
             window and have the distance to the edge of the window be
             the "radius".
+
         Note that this function is defined entirely in terms of other,
         lower level Python functions.
 
@@ -609,11 +611,12 @@ class Image(CartaView):
         system: string
             The desired coordinate system.
             Acceptable systems are:
-                * J2000
-                * B1950
-                * ICRS
-                * Galactic
-                * Ecliptic
+
+                - J2000
+                - B1950
+                - ICRS
+                - Galactic
+                - Ecliptic
 
         Returns
         -------
@@ -725,8 +728,8 @@ class Image(CartaView):
         Set whether or not grid control settings should apply to all
         images on the set.
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         applyAll: boolean
             True if the settings apply to all images on the stack;
             False otherwise.
@@ -746,7 +749,7 @@ class Image(CartaView):
         Set the grid coordinate system.
 
         Parameters
-        ---------
+        ----------
         coordSystem: string
             An identifier for a grid coordinate system.
 
@@ -1021,7 +1024,7 @@ class Image(CartaView):
         """
         Set whether or not to show grid axis ticks.
 
-        Paramters
+        Parameters
         ----------
             showTicks: boolean
                 True if the grid axis ticks should be shown; False

--- a/carta/scriptedClient/layer2.py
+++ b/carta/scriptedClient/layer2.py
@@ -8,8 +8,8 @@ class TagMessage:
     """
     TagMessage contains a string tag and string data.
 
-    Paramters
-    ---------
+    Parameters
+    ----------
     tag: string
         The type of the message. Currently supported tags are "json" and
         "async".

--- a/carta/scriptedClient/snapshot.py
+++ b/carta/scriptedClient/snapshot.py
@@ -6,7 +6,7 @@ class Snapshot:
     Represents a snapshot of a saved application state.
 
     Parameters
-    ---------
+    ----------
     sessionId: string
         An identifier for a user session.
 

--- a/carta/scriptedClient/tagconnector.py
+++ b/carta/scriptedClient/tagconnector.py
@@ -29,9 +29,13 @@ class TagConnector:
     def cmdTagList(self, cmd, ** kwargs):
         """
         Send a tag message, return a list.
+
         A command may have no arguments, e.g.:
+
             cmdTagList("commandString").
+
         Arguments, when present, are specified as key-value pairs, e.g.:
+
             cmTagList("commandString", arg1=1, arg2=True, arg3="foo")
 
         Parameters

--- a/docs/source/api/api.rst
+++ b/docs/source/api/api.rst
@@ -1,5 +1,5 @@
-Pyhon Auto Generated Documentation
-==================================
+Python Auto Generated Documentation
+===================================
 
 The animator module
 -------------------
@@ -9,14 +9,14 @@ The animator module
    :member-order: bysource
 
 The cartaview module
--------------------
+--------------------
 
 .. automodule:: cartaview
    :members:
    :member-order: bysource
 
 The histogram module
--------------------
+--------------------
 
 .. automodule:: histogram
    :members:
@@ -37,28 +37,28 @@ The colormap module
    :member-order: bysource
 
 The image module
--------------------
+----------------
 
 .. automodule:: image
    :members:
    :member-order: bysource
 
 The layer1 module
--------------------
+-----------------
 
 .. automodule:: layer1
    :members:
    :member-order: bysource
 
 The layer2 module
--------------------
+-----------------
 
 .. automodule:: layer2
    :members:
    :member-order: bysource
 
 The layer3 module
--------------------
+-----------------
 
 .. automodule:: layer3
    :members:
@@ -72,7 +72,7 @@ The snapshot module
    :member-order: bysource
 
 The tagconnector module
--------------------
+-----------------------
 
 .. automodule:: tagconnector
    :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,6 +35,8 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.pngmath',
     'sphinx.ext.viewcode',
+    'sphinx.ext.autosummary',
+    'numpydoc',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -289,3 +291,5 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+numpydoc_show_class_members = False


### PR DESCRIPTION
@astrilet Here are the changes I was telling you about. They are all quite minor, but when coupled with the numpydoc extension for Sphinx, they should allow the documentation to compile without any errors.