### PR TITLE
Added explicit cast to initializer list to fix build error with Qt 5.4

### DIFF
--- a/carta/cpp/plugins/DevIntegration/DevIntegration.cpp
+++ b/carta/cpp/plugins/DevIntegration/DevIntegration.cpp
@@ -37,7 +37,7 @@ DevIntegrationPlugin::handleHook( BaseHook & hookData )
             hook.result.clear();
         }
         else {
-            hook.result = {
+            hook.result = QStringList{
                 file
             };
         }


### PR DESCRIPTION
Creating a pull request against develop instead of master, as requested.

While attempting to build CARTAvis with Qt 5.4, David and I encountered this error:

```
g++-4.8 -c -pipe -DCARTA_RUNTIME_CHECKS=1 -O2 -Wall -W -std=c++0x -D_REENTRANT -fPIC -DQT_PLUGIN -DQT_GUI_LIB -DQT_CORE_LIB -I/home/adrianna/repos/CARTAvis/carta/cpp/plugins/DevIntegration -I. -I/home/adrianna/repos/CARTAvis/carta/cpp -I/home/adrianna/repos/CARTAvis/carta/cpp -I/opt/qt54/include -I/opt/qt54/include/QtGui -I/opt/qt54/include/QtCore -I. -I/opt/qt54/mkspecs/linux-g++ -o DevIntegration.o /home/adrianna/repos/CARTAvis/carta/cpp/plugins/DevIntegration/DevIntegration.cpp
/home/adrianna/repos/CARTAvis/carta/cpp/plugins/DevIntegration/DevIntegration.cpp: In member function ‘virtual bool DevIntegrationPlugin::handleHook(BaseHook&)’:
/home/adrianna/repos/CARTAvis/carta/cpp/plugins/DevIntegration/DevIntegration.cpp:40:25: error: ambiguous overload for ‘operator=’ (operand types are ‘Carta::Lib::Hooks::GetInitialFileList::ResultType {aka QStringList}’ and ‘<brace-enclosed initializer list>’)
             hook.result = {
                         ^
/home/adrianna/repos/CARTAvis/carta/cpp/plugins/DevIntegration/DevIntegration.cpp:40:25: note: candidates are:
In file included from /opt/qt54/include/QtCore/qvariant.h:44:0,
                 from /opt/qt54/include/QtCore/qlocale.h:37,
                 from /opt/qt54/include/QtCore/qtextstream.h:40,
                 from /opt/qt54/include/QtCore/qdebug.h:42,
                 from /opt/qt54/include/QtCore/QDebug:1,
                 from /home/adrianna/repos/CARTAvis/carta/cpp/CartaLib/CartaLib.h:10,
                 from /home/adrianna/repos/CARTAvis/carta/cpp/CartaLib/ICoordinateFormatter.h:10,
                 from /home/adrianna/repos/CARTAvis/carta/cpp/CartaLib/IImage.h:25,
                 from /home/adrianna/repos/CARTAvis/carta/cpp/CartaLib/IPlugin.h:6,
                 from /home/adrianna/repos/CARTAvis/carta/cpp/plugins/DevIntegration/DevIntegration.h:5,
                 from /home/adrianna/repos/CARTAvis/carta/cpp/plugins/DevIntegration/DevIntegration.cpp:1:
/opt/qt54/include/QtCore/qstringlist.h:66:18: note: QStringList& QStringList::operator=(const QList<QString>&)
     QStringList &operator=(const QList<QString> &other)
                  ^
/opt/qt54/include/QtCore/qstringlist.h:69:18: note: QStringList& QStringList::operator=(QList<QString>&&)
     QStringList &operator=(QList<QString> &&other)
                  ^
/opt/qt54/include/QtCore/qstringlist.h:53:7: note: QStringList& QStringList::operator=(const QStringList&)
 class QStringList : public QList<QString>
       ^
/opt/qt54/include/QtCore/qstringlist.h:53:7: note: QStringList& QStringList::operator=(QStringList&&)
```

This can be fixed with an explicit cast of the initializer list to QStringList.  This change appears to be backwards-compatible with Qt 5.3.