### PR TITLE
Temporarily set numeric locale to C before using AST to parse a FITS …

### DIFF
--- a/carta/cpp/plugins/WcsPlotter/AstGridPlotter.cpp
+++ b/carta/cpp/plugins/WcsPlotter/AstGridPlotter.cpp
@@ -441,10 +441,7 @@ AstGridPlotter::plot()
     // locale so that we can switch back afterwards and minimise impact
     // on the rest of the application.
     
-    char *old_locale, *saved_locale;
-    old_locale = setlocale(LC_NUMERIC, NULL);
-    saved_locale = strdup(old_locale);
-    setlocale(LC_NUMERIC, "C");
+    std::string oldLocale = setlocale(LC_NUMERIC, "C");
 
     // get rid of any ast errors from previous calls, just in case
     astClearStatus;
@@ -587,8 +584,7 @@ AstGridPlotter::plot()
     
     // Restore previous numeric locale
     
-    setlocale (LC_NUMERIC, saved_locale);
-    free(saved_locale);
+    setlocale(LC_NUMERIC, oldLocale.c_str());
 
     return true;
 } // plot

--- a/carta/cpp/plugins/WcsPlotter/AstGridPlotter.cpp
+++ b/carta/cpp/plugins/WcsPlotter/AstGridPlotter.cpp
@@ -3,6 +3,7 @@
 #include "grfdriver.h"
 
 #include <string.h>
+#include <locale.h>
 extern "C" {
 #include <ast.h>
 };
@@ -433,6 +434,17 @@ AstGridPlotter::plot()
     grfGlobals()-> vgComposer = m_vgc;
     // pre-cache some things
     grfGlobals()-> prepare();
+    
+    // Temporarily override numeric locale, otherwise AST will fail to 
+    // parse floating point numbers in the FITS header if the user's 
+    // locale uses a comma as a decimal separator. Back up the old 
+    // locale so that we can switch back afterwards and minimise impact
+    // on the rest of the application.
+    
+    char *old_locale, *saved_locale;
+    old_locale = setlocale(LC_NUMERIC, NULL);
+    saved_locale = strdup(old_locale);
+    setlocale(LC_NUMERIC, "C");
 
     // get rid of any ast errors from previous calls, just in case
     astClearStatus;
@@ -572,6 +584,11 @@ AstGridPlotter::plot()
     plot = (AstPlot *) astAnnul( plot );
     wcsinfo = (AstFrameSet *) astAnnul( wcsinfo );
     fitschan = (AstFitsChan *) astAnnul( fitschan );
+    
+    // Restore previous numeric locale
+    
+    setlocale (LC_NUMERIC, saved_locale);
+    free(saved_locale);
 
     return true;
 } // plot


### PR DESCRIPTION
I encountered a bizarre bug in the WcsPlotter plugin when installing CARTA on my laptop, which I finally tracked down yesterday to an unfortunate interaction between the South African numeric locale (which uses the comma as a decimal separator) and the AST library (which uses the locale-aware sscanf function to parse FITS headers, which use the decimal point as a decimal separator).

I filed a bug against AST:
https://github.com/Starlink/starlink/issues/53

... but it's uncertain how, when and if the AST developers will choose to address locale issues like this.  In the meantime I have followed their suggestion and set the locale in the calling code. To minimise the impact that this has on the rest of the code, I save the old locale and restore it afterwards, and I change only LC_NUMERIC and not the rest of the locale.

I have closely followed the code example given in the libc documentation:
https://www.gnu.org/software/libc/manual/html_node/Setting-the-Locale.html