### PR TITLE
Fixing missing symbol error when running on OSX

### DIFF
--- a/carta/cpp/plugins/ImageStatistics/ImageStatistics.pro
+++ b/carta/cpp/plugins/ImageStatistics/ImageStatistics.pro
@@ -28,6 +28,7 @@ LIBS += $${casacoreLIBS}
 LIBS += -L$${WCSLIBDIR}/lib -lwcs
 LIBS += -L$${CFITSIODIR}/lib -lcfitsio
 LIBS += -L$${IMAGEANALYSISDIR}/lib -limageanalysis
+LIBS += -L$$OUT_PWD/../../plugins/CasaImageLoader -lplugin
 LIBS += -L$$OUT_PWD/../../core/ -lcore
 LIBS += -L$$OUT_PWD/../../CartaLib/ -lCartaLib
 


### PR DESCRIPTION
OSX complained about missing symbol when loading the plugin.
__Z20cartaII2casaII_floatNSt3__110shared_ptrIN5Carta3Lib5Image14ImageInterfaceEE
can be found in CasaImageLoader.