### PR TITLE
A configuration option for Flex/Bison include dir

### DIFF
--- a/carta/cpp/common_config.pri
+++ b/carta/cpp/common_config.pri
@@ -10,6 +10,7 @@ ASTLIBDIR = ../../ThirdParty/ast-8.0.2
 WCSLIBDIR=../../ThirdParty/wcslib
 CFITSIODIR=../../ThirdParty/cfitsio-shared
 IMAGEANALYSISDIR=../../ThirdParty/imageanalysis-2.10.2016
+FLEXANDBISONDIR=../../ThirdParty/flexandbison
 
 # don't edit these:
 # relative links are replaced by absolute paths
@@ -19,3 +20,4 @@ ASTLIBDIR=$$absolute_path($${ASTLIBDIR})
 WCSLIBDIR=$$absolute_path($${WCSLIBDIR})
 CFITSIODIR=$$absolute_path($${CFITSIODIR})
 IMAGEANALYSISDIR=$$absolute_path($${IMAGEANALYSISDIR})
+FLEXANDBISONDIR=$$absolute_path($${FLEXANDBISONDIR})

--- a/carta/cpp/plugins/RegionDs9/RegionDs9.pro
+++ b/carta/cpp/plugins/RegionDs9/RegionDs9.pro
@@ -35,7 +35,11 @@ LIBS += -L$${WCSLIBDIR}/lib -lwcs
 LIBS += -L$${CFITSIODIR}/lib -lcfitsio
 LIBS += -L$$OUT_PWD/../../core/ -lcore
 LIBS += -L$$OUT_PWD/../../CartaLib/ -lCartaLib
-LIBS += -lfl -ly
+unix:macx{
+    LIBS += -L$${FLEXANDBISONDIR} -lfl -ly
+} else {
+    LIBS += -lfl -ly
+}
 
 INCLUDEPATH += $${CASACOREDIR}/include
 INCLUDEPATH += $${CASACOREDIR}/include/casacore


### PR DESCRIPTION
Added a configuration option for Flex/Bison directory. This
is necessary for Mac builds, since Mac doesn't come with Flex by
default.