### PR TITLE
preallocate space for copy of data and list of corresponding indices,…

### DIFF
--- a/carta/cpp/core/Data/Image/DataSource.cpp
+++ b/carta/cpp/core/Data/Image/DataSource.cpp
@@ -68,6 +68,13 @@ void DataSource::_copyData( int frameLow, int frameHigh, int spectralIndex,
         // read in all values from the view into an array
         // we need our own copy because we'll do quickselect on it...
         int index = 0;
+	
+	// Preallocate space for both of these copies to avoid 
+	// running out of memory unnecessarily through dynamic allocation
+	std::vector<int> dims = rawData->dims();
+	int total_size = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<int>());
+	allIndices.reserve(total_size);
+	allValues.reserve(total_size);
 
         view.forEach( [& allValues, &allIndices, &index] ( const double  val ) {
             if ( std::isfinite( val ) ) {

--- a/carta/cpp/core/Data/Image/DataSource.cpp
+++ b/carta/cpp/core/Data/Image/DataSource.cpp
@@ -68,13 +68,13 @@ void DataSource::_copyData( int frameLow, int frameHigh, int spectralIndex,
         // read in all values from the view into an array
         // we need our own copy because we'll do quickselect on it...
         int index = 0;
-	
-	// Preallocate space for both of these copies to avoid 
-	// running out of memory unnecessarily through dynamic allocation
-	std::vector<int> dims = rawData->dims();
-	int total_size = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<int>());
-	allIndices.reserve(total_size);
-	allValues.reserve(total_size);
+    
+        // Preallocate space for both of these copies to avoid 
+        // running out of memory unnecessarily through dynamic allocation
+        std::vector<int> dims = rawData->dims();
+        int total_size = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<int>());
+        allIndices.reserve(total_size);
+        allValues.reserve(total_size);
 
         view.forEach( [& allValues, &allIndices, &index] ( const double  val ) {
             if ( std::isfinite( val ) ) {


### PR DESCRIPTION
… to avoid running out of memory unnecessarily during dynamic allocation

This change helps to mitigate [issue 185](https://github.com/Astroua/CARTAvis/issues/185) (bad_alloc being thrown when these vectors are resized dynamically during the copy).

Is there a better way to calculate the maximum total size of the data than multiplying the dimensions together?